### PR TITLE
FEAT: Require terms and conditions agreement for sign-up

### DIFF
--- a/web/components/AuthForm.tsx
+++ b/web/components/AuthForm.tsx
@@ -7,6 +7,8 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Alert } from "@/components/ui/alert";
+import { Checkbox } from "@/components/ui/checkbox"; // Added Checkbox import
+import Link from "next/link"; // Added Link import
 import { useTranslations } from "next-intl";
 
 type Mode = "login" | "signup";
@@ -19,6 +21,7 @@ export default function AuthForm() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const [agreedToTerms, setAgreedToTerms] = useState(false); // Added state for terms agreement
 
   const router = useRouter();
 
@@ -91,9 +94,29 @@ export default function AuthForm() {
               disabled={loading}
             />
           </div>
+          {mode === "signup" && (
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="terms"
+                checked={agreedToTerms}
+                onCheckedChange={(checked) => setAgreedToTerms(checked as boolean)}
+                disabled={loading}
+              />
+              <Label htmlFor="terms" className="text-sm font-normal">
+                {tAuth('agreeTo')}{' '}
+                <Link href="/terms.html" target="_blank" className="underline hover:text-primary">
+                  {tAuth('termsAndConditions')}
+                </Link>
+              </Label>
+            </div>
+          )}
           {error && <Alert variant="destructive">{error}</Alert>}
           {success && <Alert variant="default">{success}</Alert>}
-          <Button type="submit" className="w-full" disabled={loading}>
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={loading || (mode === "signup" && !agreedToTerms)}
+          >
             {loading ? (mode === "login" ? tAuth('signingIn') : tAuth('signingUp')) : (mode === "login" ? tAuth('signInTitle') : tAuth('signUpTitle'))}
           </Button>
         </form>

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -122,6 +122,8 @@
     "signingIn": "Signing in...",
     "signingUp": "Signing up...",
     "dontHaveAccount": "Don't have an account? Sign up",
-    "alreadyHaveAccount": "Already have an account? Sign in"
+    "alreadyHaveAccount": "Already have an account? Sign in",
+    "agreeTo": "I agree to the",
+    "termsAndConditions": "Terms and Conditions"
   }
 }

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -117,6 +117,8 @@
     "signingIn": "Masuk...",
     "signingUp": "Mendaftar...",
     "dontHaveAccount": "Belum punya akun? Daftar",
-    "alreadyHaveAccount": "Sudah punya akun? Masuk"
+    "alreadyHaveAccount": "Sudah punya akun? Masuk",
+    "agreeTo": "Saya setuju dengan",
+    "termsAndConditions": "Syarat dan Ketentuan"
   }
 }

--- a/web/public/terms.html
+++ b/web/public/terms.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms and Conditions</title>
+    <style>
+        body { font-family: sans-serif; margin: 20px; line-height: 1.6; }
+        h1 { text-align: center; }
+        h2 { margin-top: 30px; }
+    </style>
+</head>
+<body>
+    <h1>Terms and Conditions</h1>
+    <p>Last updated: [Date]</p>
+
+    <p>Please read these Terms and Conditions ("Terms", "Terms and Conditions") carefully before using this web application (the "Service") operated by [Your Company Name] ("us", "we", or "our").</p>
+
+    <p>Your access to and use of the Service is conditioned on your acceptance of and compliance with these Terms. These Terms apply to all visitors, users, and others who access or use the Service.</p>
+
+    <p>By accessing or using the Service you agree to be bound by these Terms. If you disagree with any part of the terms then you may not access the Service.</p>
+
+    <h2>1. Accounts</h2>
+    <p>When you create an account with us, you must provide us with information that is accurate, complete, and current at all times. Failure to do so constitutes a breach of the Terms, which may result in immediate termination of your account on our Service.</p>
+    <p>You are responsible for safeguarding the password that you use to access the Service and for any activities or actions under your password, whether your password is with our Service or a third-party service.</p>
+    <p>You agree not to disclose your password to any third party. You must notify us immediately upon becoming aware of any breach of security or unauthorized use of your account.</p>
+
+    <h2>2. Intellectual Property</h2>
+    <p>The Service and its original content, features, and functionality are and will remain the exclusive property of [Your Company Name] and its licensors. The Service is protected by copyright, trademark, and other laws of both the [Your Country] and foreign countries.</p>
+    <p>Our trademarks and trade dress may not be used in connection with any product or service without the prior written consent of [Your Company Name].</p>
+
+    <h2>3. Links To Other Web Sites</h2>
+    <p>Our Service may contain links to third-party web sites or services that are not owned or controlled by [Your Company Name].</p>
+    <p>[Your Company Name] has no control over, and assumes no responsibility for, the content, privacy policies, or practices of any third party web sites or services. You further acknowledge and agree that [Your Company Name] shall not be responsible or liable, directly or indirectly, for any damage or loss caused or alleged to be caused by or in connection with use of or reliance on any such content, goods or services available on or through any such web sites or services.</p>
+    <p>We strongly advise you to read the terms and conditions and privacy policies of any third-party web sites or services that you visit.</p>
+
+    <h2>4. Termination</h2>
+    <p>We may terminate or suspend your account immediately, without prior notice or liability, for any reason whatsoever, including without limitation if you breach the Terms.</p>
+    <p>Upon termination, your right to use the Service will immediately cease. If you wish to terminate your account, you may simply discontinue using the Service.</p>
+    <p>All provisions of the Terms which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity and limitations of liability.</p>
+
+    <h2>5. Disclaimer</h2>
+    <p>Your use of the Service is at your sole risk. The Service is provided on an "AS IS" and "AS AVAILABLE" basis. The Service is provided without warranties of any kind, whether express or implied, including, but not limited to, implied warranties of merchantability, fitness for a particular purpose, non-infringement or course of performance.</p>
+    <p>[Your Company Name] its subsidiaries, affiliates, and its licensors do not warrant that a) the Service will function uninterrupted, secure or available at any particular time or location; b) any errors or defects will be corrected; c) the Service is free of viruses or other harmful components; or d) the results of using the Service will meet your requirements.</p>
+
+    <h2>6. Governing Law</h2>
+    <p>These Terms shall be governed and construed in accordance with the laws of [Your Country/State], without regard to its conflict of law provisions.</p>
+    <p>Our failure to enforce any right or provision of these Terms will not be considered a waiver of those rights. If any provision of these Terms is held to be invalid or unenforceable by a court, the remaining provisions of these Terms will remain in effect. These Terms constitute the entire agreement between us regarding our Service, and supersede and replace any prior agreements we might have between us regarding the Service.</p>
+
+    <h2>7. Changes</h2>
+    <p>We reserve the right, at our sole discretion, to modify or replace these Terms at any time. If a revision is material we will try to provide at least 30 days notice prior to any new terms taking effect. What constitutes a material change will be determined at our sole discretion.</p>
+    <p>By continuing to access or use our Service after those revisions become effective, you agree to be bound by the revised terms. If you do not agree to the new terms, please stop using the Service.</p>
+
+    <h2>8. Contact Us</h2>
+    <p>If you have any questions about these Terms, please contact us.</p>
+    <p>[Provide contact information, e.g., email address]</p>
+
+</body>
+</html>


### PR DESCRIPTION
Implemented a terms and conditions checkbox on the sign-up page. The sign-up button is now disabled until the user agrees to the terms.

- Added a `terms.html` page with generic terms and conditions.
- Modified `AuthForm.tsx` to include the checkbox and conditional logic.
- Updated English and Indonesian translation files with new keys.